### PR TITLE
Add IMPERICS_SHAREDDIR env var to CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
 install:
   - conda env create -q -f ci/requirements-$CONDA_ENV.yml
   - source activate test_env
+  - export IMPERICS_SHAREDDIR=/tmp
   - pip install .[test]
 
 script:


### PR DESCRIPTION
Our CI tests are currently broken because they're looking for a ../server.yml file. Rather than writing this file, we can instead set the `IMPERICS_SHAREDDIR` environment variable to some path and bob's your uncle.