### PR TITLE
Add findsplinemax(), refactor minspline.py into minmaxspline.py

### DIFF
--- a/impactcommon/math/minmaxspline.py
+++ b/impactcommon/math/minmaxspline.py
@@ -1,0 +1,81 @@
+######
+# These functions calculate the minima and maxima of a cubic spline.
+# The main function is `findsplinemin` and `findsplinemax`.
+######
+
+## Find extremum of expression of the form intercept x + sum(coeffs[i] (x - offsets[i])^3)
+import numpy as np
+from openest.models.curve import CubicSplineCurve
+
+def quadratic(aa, bb, cc):
+    if bb**2 - 4 * aa * cc < 0:
+        return np.array([]), np.array([])
+
+    one = (-bb + np.sqrt(bb**2 - 4 * aa * cc)) / (2 * aa)
+    two = (-bb - np.sqrt(bb**2 - 4 * aa * cc)) / (2 * aa)
+    points = np.array([one, two])
+    seconds = np.sign(2 * aa * points + bb)
+
+    return points, seconds
+
+def findextremes(intercept, coeffs, offsets):
+    # Finds where intercept + sum(3 coeffs[i] (x - offsets[i])^2) = 0
+    coeffs = np.array(coeffs)
+    offsets = np.array(offsets)
+    aa = np.sum(3 * coeffs)
+    bb = np.sum(-6 * coeffs * offsets)
+    cc = intercept + np.sum(3 * coeffs * (offsets**2))
+
+    return quadratic(aa, bb, cc)
+
+def findminmaxwithin(intercept, coeffs, offsets, minx, maxx):
+    points, seconds = findextremes(intercept, coeffs, offsets)
+    if len(points) == 0:
+        return points, points
+
+    return (points[(seconds > 0) * (points >= minx) * (points <= maxx)],
+            points[(seconds < 0) * (points >= minx) * (points <= maxx)])
+
+def findsplineminmax(knots, coeffs, minx, maxx):
+    allpoints = []
+    knotKm1 = ([], []) # coeffs, offsets for x > knots[-2]
+    knotK = ([], []) # coeffs, offsets for x > knots[-1]
+    for kk in range(1, len(knots)-1):
+        minp, maxp = findminmaxwithin(coeffs[0], coeffs[1:kk+1], knots[0:kk], knots[kk-1], knots[kk])
+        allpoints.extend(minp)
+        allpoints.extend(maxp)
+
+        knotKm1[0].extend([coeffs[kk], -coeffs[kk] * (knots[-1] - knots[kk-1]) / (knots[-1] - knots[-2])])
+        knotKm1[1].extend([knots[kk-1], knots[-2]])
+        knotK[0].extend([coeffs[kk], -coeffs[kk] * (knots[-1] - knots[kk-1]) / (knots[-1] - knots[-2]), coeffs[kk] * (knots[-2] - knots[kk-1]) / (knots[-1] - knots[-2])])
+        knotK[1].extend([knots[kk-1], knots[-2], knots[-1]])
+
+    minp, maxp = findminmaxwithin(coeffs[0], knotKm1[0], knotKm1[1], knots[-2], knots[-1])
+    allpoints.extend(minp)
+    allpoints.extend(maxp)
+    minp, maxp = findminmaxwithin(coeffs[0], knotK[0], knotK[1], knots[-1], np.inf)
+    allpoints.extend(minp)
+    allpoints.extend(maxp)
+
+    allpoints.extend(knots) # Could also be edge-points
+
+    # Drop all poitns outside of range
+    allpoints = np.array(allpoints)
+    allpoints = list(allpoints[(allpoints > minx) * (allpoints < maxx)])
+    allpoints.extend([minx, maxx])
+
+    # Determine the true lowest and highest
+    curve = CubicSplineCurve(knots, coeffs)
+    y = curve(np.array(allpoints))
+    minpt = np.argmin(y)
+    maxpt = np.argmax(y)
+
+    return allpoints[minpt], allpoints[maxpt]
+
+def findsplinemin(*args, **kwargs):
+    x, _ = findsplineminmax(*args, **kwargs)
+    return x
+
+def findsplinemax(*args, **kwargs):
+    _, x = findsplineminmax(*args, **kwargs)
+    return x

--- a/impactcommon/math/minspline.py
+++ b/impactcommon/math/minspline.py
@@ -4,67 +4,10 @@
 ######
 
 ## Find minimum of expression of the form intercept x + sum(coeffs[i] (x - offsets[i])^3)
-import numpy as np
-from openest.models.curve import CubicSplineCurve
 
-def quadratic(aa, bb, cc):
-    if bb**2 - 4 * aa * cc < 0:
-        return np.array([]), np.array([])
+# For legacy purpose
+from impactcommon.math.minmaxspline import findsplinemin, findextremes
 
-    one = (-bb + np.sqrt(bb**2 - 4 * aa * cc)) / (2 * aa)
-    two = (-bb - np.sqrt(bb**2 - 4 * aa * cc)) / (2 * aa)
-    points = np.array([one, two])
-    seconds = np.sign(2 * aa * points + bb)
-
-    return points, seconds
-
-def findextremes(intercept, coeffs, offsets):
-    # Finds where intercept + sum(3 coeffs[i] (x - offsets[i])^2) = 0
-    coeffs = np.array(coeffs)
-    offsets = np.array(offsets)
-    aa = np.sum(3 * coeffs)
-    bb = np.sum(-6 * coeffs * offsets)
-    cc = intercept + np.sum(3 * coeffs * (offsets**2))
-
-    return quadratic(aa, bb, cc)
-
-def findminwithin(intercept, coeffs, offsets, minx, maxx):
-    points, seconds = findextremes(intercept, coeffs, offsets)
-    if len(points) == 0:
-        return points
-
-    return points[(seconds > 0) * (points >= minx) * (points <= maxx)]
-
-def findsplinemin(knots, coeffs, minx, maxx):
-    allpoints = []
-    knotKm1 = ([], []) # coeffs, offsets for x > knots[-2]
-    knotK = ([], []) # coeffs, offsets for x > knots[-1]
-    for kk in range(1, len(knots)-1):
-        points = findminwithin(coeffs[0], coeffs[1:kk+1], knots[0:kk], knots[kk-1], knots[kk])
-        allpoints.extend(points)
-
-        knotKm1[0].extend([coeffs[kk], -coeffs[kk] * (knots[-1] - knots[kk-1]) / (knots[-1] - knots[-2])])
-        knotKm1[1].extend([knots[kk-1], knots[-2]])
-        knotK[0].extend([coeffs[kk], -coeffs[kk] * (knots[-1] - knots[kk-1]) / (knots[-1] - knots[-2]), coeffs[kk] * (knots[-2] - knots[kk-1]) / (knots[-1] - knots[-2])])
-        knotK[1].extend([knots[kk-1], knots[-2], knots[-1]])
-
-    points = findminwithin(coeffs[0], knotKm1[0], knotKm1[1], knots[-2], knots[-1])
-    allpoints.extend(points)
-    points = findminwithin(coeffs[0], knotK[0], knotK[1], knots[-1], np.inf)
-    allpoints.extend(points)
-
-    allpoints.extend(knots) # Could also be edge-points
-
-    # Drop all poitns outside of range
-    allpoints = np.array(allpoints)
-    allpoints = list(allpoints[(allpoints > minx) * (allpoints < maxx)])
-    allpoints.extend([minx, maxx])
-
-    # Determine the true lowest
-    curve = CubicSplineCurve(knots, coeffs)
-    minpt = np.argmin(curve(np.array(allpoints)))
-
-    return allpoints[minpt]
 
 if __name__ == '__main__':
     print(findextremes(-0.088404222535054311, [0.00044585141069226897, -0.0013680191382785048, 0.0015570001425749581, -0.00014956629970445078, -0.0036869690281538109], [-12, -7, 0, 10, 18]))

--- a/tests/test_math/test_minmaxspline.py
+++ b/tests/test_math/test_minmaxspline.py
@@ -1,6 +1,6 @@
 import numpy as np
 import numpy.testing as npt
-from impactcommon.math.minspline import findextremes, findsplinemin
+from impactcommon.math.minmaxspline import findextremes, findsplinemin, findsplinemax
 
 
 def test_findextremes():
@@ -41,6 +41,28 @@ def test_findsplinemin():
         ],
         minx=10,
         maxx=25,
+    )
+
+    npt.assert_allclose([actual], [expected])
+
+
+def test_findsplinemax():
+    """Simple test of findsplinemax output"""
+    expected = 32
+
+    actual = findsplinemax(
+        knots=[-12, -7, 0, 10, 18, 23, 28, 33],
+        coeffs=[
+            -0.088404222535054311,
+            0.00044585141069226897,
+            -0.0013680191382785048,
+            0.0015570001425749581,
+            -0.00014956629970445078,
+            -0.0036869690281538109,
+            0.011688014471165964,
+        ],
+        minx=0,
+        maxx=32,
     )
 
     npt.assert_allclose([actual], [expected])


### PR DESCRIPTION
Changes in this PR:
- Adds `impactcommon.math.minmaxspline.findsplinemax()`. It finds the local maxima of an open estimate-style cubic spline `Curve`.
- Refactors logic for `findsplinemin()` to `impactcommon/math/minmaxspline.py` but maintains reference in `impactcommon/math/minspline.py` for backwards compatibility.
- Adds unit tests for new `findsplinemax()`.

Needed for downstream labor sector projection development.

Close #15 