### PR TITLE
Fix KernelAverager.get() so returns scalar, never 1d array

### DIFF
--- a/impactcommon/math/averages.py
+++ b/impactcommon/math/averages.py
@@ -44,14 +44,14 @@ class MeanAverager(MemoryAverager):
     Simple mean running average.
     """
     def get(self):
-        return np.mean(self.values)
+        return np.mean(self.values).item()
 
 class MedianAverager(MemoryAverager):
     """
     Simple median running average.
     """
     def get(self):
-        return np.median(self.values)
+        return np.median(self.values).item()
 
 class BucketAverager(RunningStatistic):
     """

--- a/impactcommon/math/averages.py
+++ b/impactcommon/math/averages.py
@@ -46,6 +46,13 @@ class MeanAverager(MemoryAverager):
     def get(self):
         return np.mean(self.values).item()
 
+class MedianAverager(MemoryAverager):
+    """
+    Simple median running average.
+    """
+    def get(self):
+        return np.median(self.values).item()
+
 class BucketAverager(RunningStatistic):
     """
     Bucket average, equivalent to an exponential kernel or Bayesian update.

--- a/impactcommon/math/averages.py
+++ b/impactcommon/math/averages.py
@@ -87,11 +87,12 @@ class KernelAverager(MemoryAverager):
     def get(self):
         if self.write_index is None or self.write_index == 0:
             subkernel = self.kernel[-len(self.values):]
-            return np.dot(subkernel, self.values) / np.sum(subkernel)
+            out = np.dot(subkernel, self.values) / np.sum(subkernel)
         else:
             recentkernel = self.kernel[-self.write_index:]
             olderkernel = self.kernel[:-self.write_index]
-            return np.dot(recentkernel, self.values[:self.write_index]) + np.dot(olderkernel, self.values[self.write_index:])
+            out = np.dot(recentkernel, self.values[:self.write_index]) + np.dot(olderkernel, self.values[self.write_index:])
+        return out.item()
 
     def get_calculation(self):
         if self.write_index is None or self.write_index == 0:

--- a/impactcommon/math/averages.py
+++ b/impactcommon/math/averages.py
@@ -46,13 +46,6 @@ class MeanAverager(MemoryAverager):
     def get(self):
         return np.mean(self.values).item()
 
-class MedianAverager(MemoryAverager):
-    """
-    Simple median running average.
-    """
-    def get(self):
-        return np.median(self.values).item()
-
 class BucketAverager(RunningStatistic):
     """
     Bucket average, equivalent to an exponential kernel or Bayesian update.


### PR DESCRIPTION
Fixes inconsistent behavior with `KernelAverager` instances getting ragged arrays because `self.get()` sometimes returns 1d arrays and sometimes returns scalars. This lead to deprecation warnings and slow projection speed in projection configurations using a Bartlett running average.

`KernelAverager.get()` should now always return a scalar.

Also:

- `MedianAverager.get()`
- `MeanAverager.get()`
