### PR TITLE
Fast running stats

### DIFF
--- a/impactcommon/math/averages.py
+++ b/impactcommon/math/averages.py
@@ -1,37 +1,4 @@
 import numpy as np
-import numba as nb
-
-@nb.njit 
-def compiled_npmean(x):
-    return np.mean(x).item()
-
-@nb.njit 
-def compiled_npmedian(x):
-    return np.median(x).item()
-
-@nb.njit 
-def compiled_sum(x):
-    return float(sum(x))
-    
-@nb.njit 
-def compiled_npflipud(x):
-    return np.flipud(x)
-
-@nb.njit
-def compiled_bucket_updater(curlen, length, sumval, value):
-    if curlen >= length:
-        sumval = (length - 1) * sumval / curlen + value
-        if curlen > length:
-            curlen = length
-    else:
-        sumval += value
-        curlen += 1
-
-    return curlen, length, sumval
-
-@nb.njit
-def compiled_npdot(x,y):
-    return np.dot(x,y)
 
 class RunningStatistic(object):
     """
@@ -56,10 +23,10 @@ class MemoryAverager(RunningStatistic):
         super(MemoryAverager, self).__init__(length)
 
         if len(values) >= length:
-            self.values = np.array(values[-length:], dtype=np.float64)
+            self.values = np.array(values[-length:])
             self.write_index = 0 # overwrite at this location next time
         else:
-            self.values = np.array(values, dtype=np.float64)
+            self.values = list(values) # Keep as a list
             self.write_index = None # append next time
 
     def update(self, value):
@@ -67,8 +34,9 @@ class MemoryAverager(RunningStatistic):
             self.values[self.write_index] = value
             self.write_index = (self.write_index + 1) % self.length
         else:
-            self.values = np.append(self.values, value) 
+            self.values.append(value)
             if len(self.values) == self.length:
+                self.values = np.array(self.values)
                 self.write_index = 0
 
 class MeanAverager(MemoryAverager):
@@ -76,14 +44,14 @@ class MeanAverager(MemoryAverager):
     Simple mean running average.
     """
     def get(self):
-        return compiled_npmean(self.values)
+        return np.mean(self.values).item()
 
 class MedianAverager(MemoryAverager):
     """
     Simple median running average.
     """
     def get(self):
-        return compiled_npmedian(self.values)
+        return np.median(self.values).item()
 
 class BucketAverager(RunningStatistic):
     """
@@ -91,14 +59,22 @@ class BucketAverager(RunningStatistic):
     """
     def __init__(self, values, length):
         super(BucketAverager, self).__init__(length)
-        self.sumval = compiled_sum(values)
+        self.sumval = float(sum(values))
         self.curlen = len(values)
 
     def update(self, value):
-        self.curlen, self.length, self.sumval = compiled_bucket_updater(self.curlen, self.length, self.sumval, value)
+        #assert self.curlen <= self.length, "{0} > {1}".format(self.curlen, self.length)
+
+        if self.curlen >= self.length:
+            self.sumval = (self.length - 1) * self.sumval / self.curlen + value
+            if self.curlen > self.length:
+                self.curlen = self.length
+        else:
+            self.sumval += value
+            self.curlen += 1
 
     def get(self):
-        return self.sumval/self.curlen 
+        return self.sumval / self.curlen
 
 class KernelAverager(MemoryAverager):
     """
@@ -106,27 +82,28 @@ class KernelAverager(MemoryAverager):
     """
     def __init__(self, values, kernel):
         super(KernelAverager, self).__init__(values, len(kernel))
-        self.kernel = compiled_npflipud(np.array(kernel) / compiled_sum(kernel))
+        self.kernel = np.flipud(np.array(kernel) / sum(kernel))
     
     def get(self):
         if self.write_index is None or self.write_index == 0:
             subkernel = self.kernel[-len(self.values):]
-            out = compiled_npdot(subkernel, self.values) / compiled_sum(subkernel)
+            out = np.dot(subkernel, self.values) / np.sum(subkernel)
         else:
             recentkernel = self.kernel[-self.write_index:]
             olderkernel = self.kernel[:-self.write_index]
-            out = compiled_npdot(recentkernel, self.values[:self.write_index]) + compiled_npdot(olderkernel, self.values[self.write_index:])
-        return out
+            out = np.dot(recentkernel, self.values[:self.write_index]) + np.dot(olderkernel, self.values[self.write_index:])
+        return out.item()
 
     def get_calculation(self):
         if self.write_index is None or self.write_index == 0:
             subkernel = self.kernel[-len(self.values):]
-            return ' + '.join(["{0} * {1}".format(subkernel[ii] / compiled_sum(subkernel), self.values[ii]) for ii in range(len(subkernel))])
+            return ' + '.join(["{0} * {1}".format(subkernel[ii] / np.sum(subkernel), self.values[ii]) for ii in range(len(subkernel))])
         else:
             recentkernel = self.kernel[-self.write_index:]
             olderkernel = self.kernel[:-self.write_index]
             return ' + '.join(["{0} * {1}".format(recentkernel[ii], self.values[ii]) for ii in range(len(recentkernel))]) + ' + '.join(["{0} * {1}".format(olderkernel[ii], self.values[self.write_index + ii]) for ii in range(len(olderkernel))])
         
+
 class KernelMeanAverager(KernelAverager):
     """
     Kernel-based implementation of a simple running average.
@@ -139,7 +116,7 @@ class BartlettAverager(KernelAverager):
     Bartlett running average.
     """
     def __init__(self, values, length=5):
-        super(BartlettAverager, self).__init__(values, compiled_npflipud(np.arange(length) + 1.))
+        super(BartlettAverager, self).__init__(values, np.flipud(np.arange(length) + 1.))
 
 def translate(cls, length, data):
     avg = cls([], length)
@@ -153,12 +130,12 @@ def translate(cls, length, data):
 if __name__ == '__main__':
     for cls in [MeanAverager, MedianAverager, BucketAverager, KernelMeanAverager, BartlettAverager]:
         print(cls)
-        avg = cls(np.array([0,1,2,3]), 5)
+        avg = cls(list(range(4)), 5)
         print(avg.get(), (0 + 1 + 2 + 3) / 4.)
         avg.update(4)
         print(avg.get(), (0 + 1 + 2 + 3 + 4) / 5.)
         avg.update(5)
-        print(avg.get(), (0 + 1 + 2 + 3 + 4 + 5) / 5.)
+        print(avg.get(), (1 + 2 + 3 + 4 + 5) / 5.)
 
     clses = [MeanAverager, MedianAverager, BucketAverager, KernelMeanAverager, BartlettAverager]
     averages = [cls(np.zeros(25), 30) for cls in clses]

--- a/impactcommon/math/averages.py
+++ b/impactcommon/math/averages.py
@@ -1,4 +1,37 @@
 import numpy as np
+import numba as nb
+
+@nb.njit 
+def compiled_npmean(x):
+    return np.mean(x).item()
+
+@nb.njit 
+def compiled_npmedian(x):
+    return np.median(x).item()
+
+@nb.njit 
+def compiled_sum(x):
+    return float(sum(x))
+    
+@nb.njit 
+def compiled_npflipud(x):
+    return np.flipud(x)
+
+@nb.njit
+def compiled_bucket_updater(curlen, length, sumval, value):
+    if curlen >= length:
+        sumval = (length - 1) * sumval / curlen + value
+        if curlen > length:
+            curlen = length
+    else:
+        sumval += value
+        curlen += 1
+
+    return curlen, length, sumval
+
+@nb.njit
+def compiled_npdot(x,y):
+    return np.dot(x,y)
 
 class RunningStatistic(object):
     """
@@ -23,10 +56,10 @@ class MemoryAverager(RunningStatistic):
         super(MemoryAverager, self).__init__(length)
 
         if len(values) >= length:
-            self.values = np.array(values[-length:])
+            self.values = np.array(values[-length:], dtype=np.float64)
             self.write_index = 0 # overwrite at this location next time
         else:
-            self.values = list(values) # Keep as a list
+            self.values = np.array(values, dtype=np.float64)
             self.write_index = None # append next time
 
     def update(self, value):
@@ -34,9 +67,8 @@ class MemoryAverager(RunningStatistic):
             self.values[self.write_index] = value
             self.write_index = (self.write_index + 1) % self.length
         else:
-            self.values.append(value)
+            self.values = np.append(self.values, value) 
             if len(self.values) == self.length:
-                self.values = np.array(self.values)
                 self.write_index = 0
 
 class MeanAverager(MemoryAverager):
@@ -44,14 +76,14 @@ class MeanAverager(MemoryAverager):
     Simple mean running average.
     """
     def get(self):
-        return np.mean(self.values).item()
+        return compiled_npmean(self.values)
 
 class MedianAverager(MemoryAverager):
     """
     Simple median running average.
     """
     def get(self):
-        return np.median(self.values).item()
+        return compiled_npmedian(self.values)
 
 class BucketAverager(RunningStatistic):
     """
@@ -59,22 +91,14 @@ class BucketAverager(RunningStatistic):
     """
     def __init__(self, values, length):
         super(BucketAverager, self).__init__(length)
-        self.sumval = float(sum(values))
+        self.sumval = compiled_sum(values)
         self.curlen = len(values)
 
     def update(self, value):
-        #assert self.curlen <= self.length, "{0} > {1}".format(self.curlen, self.length)
-
-        if self.curlen >= self.length:
-            self.sumval = (self.length - 1) * self.sumval / self.curlen + value
-            if self.curlen > self.length:
-                self.curlen = self.length
-        else:
-            self.sumval += value
-            self.curlen += 1
+        self.curlen, self.length, self.sumval = compiled_bucket_updater(self.curlen, self.length, self.sumval, value)
 
     def get(self):
-        return self.sumval / self.curlen
+        return self.sumval/self.curlen 
 
 class KernelAverager(MemoryAverager):
     """
@@ -82,28 +106,27 @@ class KernelAverager(MemoryAverager):
     """
     def __init__(self, values, kernel):
         super(KernelAverager, self).__init__(values, len(kernel))
-        self.kernel = np.flipud(np.array(kernel) / sum(kernel))
+        self.kernel = compiled_npflipud(np.array(kernel) / compiled_sum(kernel))
     
     def get(self):
         if self.write_index is None or self.write_index == 0:
             subkernel = self.kernel[-len(self.values):]
-            out = np.dot(subkernel, self.values) / np.sum(subkernel)
+            out = compiled_npdot(subkernel, self.values) / compiled_sum(subkernel)
         else:
             recentkernel = self.kernel[-self.write_index:]
             olderkernel = self.kernel[:-self.write_index]
-            out = np.dot(recentkernel, self.values[:self.write_index]) + np.dot(olderkernel, self.values[self.write_index:])
-        return out.item()
+            out = compiled_npdot(recentkernel, self.values[:self.write_index]) + compiled_npdot(olderkernel, self.values[self.write_index:])
+        return out
 
     def get_calculation(self):
         if self.write_index is None or self.write_index == 0:
             subkernel = self.kernel[-len(self.values):]
-            return ' + '.join(["{0} * {1}".format(subkernel[ii] / np.sum(subkernel), self.values[ii]) for ii in range(len(subkernel))])
+            return ' + '.join(["{0} * {1}".format(subkernel[ii] / compiled_sum(subkernel), self.values[ii]) for ii in range(len(subkernel))])
         else:
             recentkernel = self.kernel[-self.write_index:]
             olderkernel = self.kernel[:-self.write_index]
             return ' + '.join(["{0} * {1}".format(recentkernel[ii], self.values[ii]) for ii in range(len(recentkernel))]) + ' + '.join(["{0} * {1}".format(olderkernel[ii], self.values[self.write_index + ii]) for ii in range(len(olderkernel))])
         
-
 class KernelMeanAverager(KernelAverager):
     """
     Kernel-based implementation of a simple running average.
@@ -116,7 +139,7 @@ class BartlettAverager(KernelAverager):
     Bartlett running average.
     """
     def __init__(self, values, length=5):
-        super(BartlettAverager, self).__init__(values, np.flipud(np.arange(length) + 1.))
+        super(BartlettAverager, self).__init__(values, compiled_npflipud(np.arange(length) + 1.))
 
 def translate(cls, length, data):
     avg = cls([], length)
@@ -130,12 +153,12 @@ def translate(cls, length, data):
 if __name__ == '__main__':
     for cls in [MeanAverager, MedianAverager, BucketAverager, KernelMeanAverager, BartlettAverager]:
         print(cls)
-        avg = cls(list(range(4)), 5)
+        avg = cls(np.array([0,1,2,3]), 5)
         print(avg.get(), (0 + 1 + 2 + 3) / 4.)
         avg.update(4)
         print(avg.get(), (0 + 1 + 2 + 3 + 4) / 5.)
         avg.update(5)
-        print(avg.get(), (1 + 2 + 3 + 4 + 5) / 5.)
+        print(avg.get(), (0 + 1 + 2 + 3 + 4 + 5) / 5.)
 
     clses = [MeanAverager, MedianAverager, BucketAverager, KernelMeanAverager, BartlettAverager]
     averages = [cls(np.zeros(25), 30) for cls in clses]

--- a/impactcommon/math/averages.py
+++ b/impactcommon/math/averages.py
@@ -30,16 +30,8 @@ def compiled_bucket_updater(curlen, length, sumval, value):
     return curlen, length, sumval
 
 @nb.njit
-def compiled_kernelaverager_get(write_index, kernel, values):
-    if write_index is None or write_index == 0:
-        subkernel = kernel[-len(values):]
-        out = np.dot(subkernel, values) / np.sum(subkernel)
-    else:
-        recentkernel = kernel[-write_index:]
-        olderkernel = kernel[:-write_index]
-        out = np.dot(recentkernel, values[:write_index]) + np.dot(olderkernel, values[write_index:])
-    return out
-
+def compiled_npdot(x,y):
+    return np.dot(x,y)
 
 class RunningStatistic(object):
     """
@@ -117,7 +109,14 @@ class KernelAverager(MemoryAverager):
         self.kernel = compiled_npflipud(np.array(kernel) / compiled_sum(kernel))
     
     def get(self):
-        return compiled_kernelaverager_get(self.write_index, self.kernel, self.values)
+        if self.write_index is None or self.write_index == 0:
+            subkernel = self.kernel[-len(self.values):]
+            out = compiled_npdot(subkernel, self.values) / compiled_sum(subkernel)
+        else:
+            recentkernel = self.kernel[-self.write_index:]
+            olderkernel = self.kernel[:-self.write_index]
+            out = compiled_npdot(recentkernel, self.values[:self.write_index]) + compiled_npdot(olderkernel, self.values[self.write_index:])
+        return out
 
     def get_calculation(self):
         if self.write_index is None or self.write_index == 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numba
 numpy
 pandas
 xarray


### PR DESCRIPTION
@jrising here are some attempts, using `numba`, to speed up numerical functions in `averages.py` which is used a lot for covariate averaging. The approach here was to wrap short chunks of commands doing numerical computations in functions with a numba decorator so that the function is compiled in machine code.

What I selected (and did not select) is based on quick tests of my own that showed large speedup in some cases and slow down or no changes in other cases, and the constraints of numba : 

- about speed ups. For example, a simple `float(sum(x))` executed `10^6` times on a 100 length vector takes 17 seconds with python. With numba compiled python, it takes 2.5 seconds. With similar setup, `np.mean()` computation time can be halved with numba. In contrast, I observed that numba significantly slows down a simple python native division. I am currently running full singles to look at the real-life consequences for ag and labor. 

- about constraints. I tried to wrap the shortest possible chunks of code, so that I don't encounter typing problems. I also had to change type here and there to make the code compatible with numba. 